### PR TITLE
Bump maven version to to 3.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
     <properties>
         <dep.aether.version>1.13.1</dep.aether.version>
-        <dep.maven.version>3.0.4</dep.maven.version>
+        <dep.maven.version>3.6.1</dep.maven.version>
 
         <air.check.skip-extended>true</air.check.skip-extended>
     </properties>


### PR DESCRIPTION
Maven 3.0.4 uses insecure http url http://repo.maven.apache.org/maven2 as the default repo url, but 

> Effective January 15, 2020, The Central Repository no longer supports insecure communication over plain HTTP and requires that all requests to the repository are encrypted over HTTPS

（https://stackoverflow.com/questions/59763531/maven-dependencies-are-failing-with-a-501-error)

FYI, I'm having issues with running a patched Presto on Intellij and I believe this is the cause.