### PR TITLE
Make user-defined repository parameter of ArtifactResolver constructor work

### DIFF
--- a/resolver/src/main/java/io/airlift/resolver/ArtifactResolver.java
+++ b/resolver/src/main/java/io/airlift/resolver/ArtifactResolver.java
@@ -154,13 +154,14 @@ public class ArtifactResolver
         // Hack: avoid using deprecated Maven Central URLs. The Central Repository no longer supports insecure
         // communication over plain HTTP.
         ImmutableList.Builder<RemoteRepository> allRepositories = ImmutableList.builder();
-        for (RemoteRepository repository : pom.getRemoteProjectRepositories()) {
+        // Ensure that custom repositories are used first.
+        for (RemoteRepository repository : repositories) {
             if (DEPRECATED_MAVEN_CENTRAL_URIS.contains(repository.getUrl())) {
                 repository = new RemoteRepository(repository.getId(), repository.getContentType(), MAVEN_CENTRAL_URI);
             }
             allRepositories.add(repository);
         }
-        for (RemoteRepository repository : repositories) {
+        for (RemoteRepository repository : pom.getRemoteProjectRepositories()) {
             if (DEPRECATED_MAVEN_CENTRAL_URIS.contains(repository.getUrl())) {
                 repository = new RemoteRepository(repository.getId(), repository.getContentType(), MAVEN_CENTRAL_URI);
             }

--- a/resolver/src/main/java/io/airlift/resolver/ArtifactResolver.java
+++ b/resolver/src/main/java/io/airlift/resolver/ArtifactResolver.java
@@ -19,6 +19,7 @@ import io.airlift.resolver.internal.ConsoleRepositoryListener;
 import io.airlift.resolver.internal.ConsoleTransferListener;
 import io.airlift.resolver.internal.Slf4jLoggerManager;
 import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
 import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
@@ -43,6 +44,7 @@ import org.sonatype.aether.graph.Exclusion;
 import org.sonatype.aether.impl.internal.SimpleLocalRepositoryManager;
 import org.sonatype.aether.repository.LocalRepositoryManager;
 import org.sonatype.aether.repository.RemoteRepository;
+import org.sonatype.aether.repository.RepositoryPolicy;
 import org.sonatype.aether.resolution.ArtifactResult;
 import org.sonatype.aether.resolution.DependencyRequest;
 import org.sonatype.aether.resolution.DependencyResolutionException;
@@ -60,6 +62,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -195,8 +198,21 @@ public class ArtifactResolver
             request.setSystemProperties(requiredSystemProperties());
             request.setRepositorySession(repositorySystemSession);
             request.setProcessPlugins(false);
-            request.setLocalRepository(lrs.createDefaultLocalRepository());
-            request.setRemoteRepositories(Arrays.asList(new ArtifactRepository[] {lrs.createDefaultRemoteRepository()}.clone()));
+            request.setLocalRepository(lrs.createLocalRepository(repositorySystemSession.getLocalRepository().getBasedir()));
+            List<ArtifactRepository> remoteRepositories = repositories.stream()
+                    .map(repo->{
+                        RepositoryPolicy snp = repo.getPolicy(true);
+                        RepositoryPolicy rel = repo.getPolicy(false);
+
+                        return lrs.createArtifactRepository(
+                                repo.getId(),
+                                repo.getUrl(),
+                                null,
+                                new ArtifactRepositoryPolicy(snp.isEnabled(),snp.getUpdatePolicy(),snp.getChecksumPolicy()),
+                                new ArtifactRepositoryPolicy(rel.isEnabled(),rel.getUpdatePolicy(),rel.getChecksumPolicy()));
+                    })
+                    .collect(Collectors.toList());
+            request.setRemoteRepositories(remoteRepositories);
             ProjectBuildingResult result = projectBuilder.build(pomFile, request);
             return result.getProject();
         }


### PR DESCRIPTION
Sometimes the local maven repo may not be `~/.m2/repository` .
And In my area, by some network reason we can't connect to the official  maven repo, or the official repo is too slow to use. I have to use a mirror repo to speed up the downloading.

When I construct an ArtifactResolver  Object with user-defined local repository and remote repository mirror, it can't resolve the pom.

``` java 
    String localRepo = "D:/Maven/.m2/repo";
    String mavenCenterMirror = "http://mirrors.cloud.tencent.com/nexus/repository/maven-public/";
    ArtifactResolver artifactResolver = new ArtifactResolver(localRepo, mavenCenterMirror);
    File pomFile = new File("src/test/poms/maven-core-3.0.4.pom");
```

Here is a full test code to replay the issue #20

I find this is because, in function MavenProject getMavenProject(File pomFile), it always use the default repository
``` java
request.setLocalRepository(lrs.createDefaultLocalRepository());
request.setRemoteRepositories(Arrays.asList(new ArtifactRepository[] {lrs.createDefaultRemoteRepository()}.clone()));
```

So I make this PR to set the user-defined repositories to the `request`, and I exchange the order of repositories handle to make sure the user-defined remote repository to use first.